### PR TITLE
Fix a comment regarding variable types

### DIFF
--- a/src/engine/variable.js
+++ b/src/engine/variable.js
@@ -58,7 +58,7 @@ class Variable {
     }
 
     /**
-     * Type representation for list variables.
+     * Type for broadcast messages.
      * @const {string}
      */
     static get BROADCAST_MESSAGE_TYPE () {


### PR DESCRIPTION
Looks like the author copied the comment for `BROADCAST_MESSAGE_TYPE`  from `LIST_TYPE` forgot to change it.