### PR TITLE
Named clones

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -166,42 +166,20 @@ class Scratch3ControlBlocks {
         // If clone target is not found, return
         if (!cloneTarget) return;
 
+        // Set clone name
+        let cloneName = null;
+        if (args.CLONE_NAME) {
+            cloneName = args.CLONE_NAME;
+        }
+
         // Create clone
-        const newClone = cloneTarget.makeClone();
+        const newClone = cloneTarget.makeClone(cloneName);
         if (newClone) {
             this.runtime.addTarget(newClone);
 
             // Place behind the original target.
             newClone.goBehindOther(cloneTarget);
         }
-    }
-
-    createNamedClone (args, util) {
-        // Cast arguments to string
-        args.CLONE_OPTION = Cast.toString(args.CLONE_OPTION);
-        args.CLONE_NAME = Cast.toString(args.CLONE_NAME);
-
-        // Set clone target
-        let cloneTarget;
-        if (args.CLONE_OPTION === '_myself_') {
-            cloneTarget = util.target;
-        } else {
-            cloneTarget = this.runtime.getSpriteTargetByName(args.CLONE_OPTION);
-        }
-
-        // If clone target is not found, return
-        if (!cloneTarget) return;
-
-        // Create clone
-        const newClone = cloneTarget.makeClone();
-        if (newClone) {
-            this.runtime.addTarget(newClone);
-
-            // Place behind the original target.
-            newClone.goBehindOther(cloneTarget);
-        }
-
-        newClone.cloneName = args.CLONE_NAME;
     }
 
     deleteClone (args, util) {

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -44,6 +44,9 @@ class Scratch3ControlBlocks {
         return {
             control_start_as_clone: {
                 restartExistingThreads: false
+            },
+            control_start_as_named_clone: {
+                restartExistingThreads: false
             }
         };
     }

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -32,6 +32,7 @@ class Scratch3ControlBlocks {
             control_if_else: this.ifElse,
             control_stop: this.stop,
             control_create_clone_of: this.createClone,
+            control_create_named_clone_of: this.createClone,
             control_delete_this_clone: this.deleteClone,
             control_get_counter: this.getCounter,
             control_incr_counter: this.incrCounter,
@@ -173,6 +174,34 @@ class Scratch3ControlBlocks {
             // Place behind the original target.
             newClone.goBehindOther(cloneTarget);
         }
+    }
+
+    createNamedClone (args, util) {
+        // Cast arguments to string
+        args.CLONE_OPTION = Cast.toString(args.CLONE_OPTION);
+        args.CLONE_NAME = Cast.toString(args.CLONE_NAME);
+
+        // Set clone target
+        let cloneTarget;
+        if (args.CLONE_OPTION === '_myself_') {
+            cloneTarget = util.target;
+        } else {
+            cloneTarget = this.runtime.getSpriteTargetByName(args.CLONE_OPTION);
+        }
+
+        // If clone target is not found, return
+        if (!cloneTarget) return;
+
+        // Create clone
+        const newClone = cloneTarget.makeClone();
+        if (newClone) {
+            this.runtime.addTarget(newClone);
+
+            // Place behind the original target.
+            newClone.goBehindOther(cloneTarget);
+        }
+
+        newClone.cloneName = args.CLONE_NAME;
     }
 
     deleteClone (args, util) {

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -571,7 +571,7 @@ class Blocks {
             // Update block value
             if (!block.fields[args.name]) return;
             if (args.name === 'VARIABLE' || args.name === 'LIST' ||
-                args.name === 'BROADCAST_OPTION') {
+                args.name === 'BROADCAST_OPTION' || args.name === 'CLONE_NAME_OPTION') {
                 // Get variable name using the id in args.value.
                 const variable = this.runtime.getEditingTarget().lookupVariableById(args.value);
                 if (variable) {

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -843,6 +843,9 @@ class Blocks {
             } else if (optIncludeBroadcast && blocks[blockId].fields.BROADCAST_OPTION) {
                 varOrListField = blocks[blockId].fields.BROADCAST_OPTION;
                 varType = Variable.BROADCAST_MESSAGE_TYPE;
+            } else if (blocks[blockId].fields.CLONE_NAME_OPTION) {
+                varOrListField = blocks[blockId].fields.CLONE_NAME_OPTION;
+                varType = Variable.CLONE_NAME_TYPE;
             }
             if (varOrListField) {
                 const currVarId = varOrListField.id;

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -259,7 +259,7 @@ class Target extends EventEmitter {
      * dictionary of variables.
      * @param {string} id Id of variable
      * @param {string} name Name of variable.
-     * @param {string} type Type of variable, '', 'broadcast_msg', or 'list'
+     * @param {string} type Type of variable, '', 'broadcast_msg', 'clone_name' or 'list'
      * @param {boolean} isCloud Whether the variable to create has the isCloud flag set.
      * Additional checks are made that the variable can be created as a cloud variable.
      */

--- a/src/engine/variable.js
+++ b/src/engine/variable.js
@@ -27,6 +27,8 @@ class Variable {
             this.value = [];
             break;
         case Variable.BROADCAST_MESSAGE_TYPE:
+        // fall through
+        case Variable.CLONE_NAME_TYPE:
             this.value = this.name;
             break;
         default:
@@ -64,6 +66,14 @@ class Variable {
      */
     static get BROADCAST_MESSAGE_TYPE () {
         return 'broadcast_msg';
+    }
+
+    /**
+     * Type for named sprite clones.
+     * @const {string}
+     */
+    static get CLONE_NAME_TYPE () {
+        return 'clone_name';
     }
 }
 

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -66,6 +66,13 @@ class RenderedTarget extends Target {
         this.isOriginal = true;
 
         /**
+         * If this target is a named clone, this is its name.
+         * If not, it's just null.
+         * @type {string}
+         */
+        this.cloneName = null;
+
+        /**
          * Whether this rendered target represents the Scratch stage.
          * @type {boolean}
          */
@@ -175,6 +182,9 @@ class RenderedTarget extends Target {
         if (!this.isOriginal) {
             this.runtime.startHats(
                 'control_start_as_clone', null, this
+            );
+            this.runtime.startHats(
+                'control_start_as_named_clone', null, this
             );
         }
     }

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -67,11 +67,10 @@ class RenderedTarget extends Target {
 
         /**
          * If this target is a named clone, this is its name.
-         * For unnamed clones, this is...
-         * XXX: This is a hack. Find a better way.
+         * For unnamed clones, this is null.
          * @type {string}
          */
-        this.cloneName = 'nobody_should_name_their_clones_like_this_anyway';
+        this.cloneName = null;
 
         /**
          * Whether this rendered target represents the Scratch stage.
@@ -184,10 +183,13 @@ class RenderedTarget extends Target {
             this.runtime.startHats(
                 'control_start_as_clone', null, this
             );
-            this.runtime.startHats(
-                'control_start_as_named_clone', {
-                    CLONE_NAME_OPTION: this.cloneName
-                }, this);
+            // If we're a named clone, start the named clone hats
+            if (this.cloneName) {
+                this.runtime.startHats(
+                    'control_start_as_named_clone', {
+                        CLONE_NAME_OPTION: this.cloneName }, this
+                );
+            }
         }
     }
 
@@ -1011,9 +1013,10 @@ class RenderedTarget extends Target {
     /**
      * Make a clone, copying any run-time properties.
      * If we've hit the global clone limit, returns null.
+     * @param {string} cloneName Name of the clone, null if the clone is anonymous.
      * @return {RenderedTarget} New clone.
      */
-    makeClone () {
+    makeClone (cloneName) {
         if (!this.runtime.clonesAvailable() || this.isStage) {
             return null; // Hit max clone limit, or this is the stage.
         }
@@ -1030,6 +1033,7 @@ class RenderedTarget extends Target {
         newClone.rotationStyle = this.rotationStyle;
         newClone.effects = Clone.simple(this.effects);
         newClone.variables = this.duplicateVariables();
+        newClone.cloneName = cloneName;
         newClone._edgeActivatedHatValues = Clone.simple(this._edgeActivatedHatValues);
         newClone.initDrawable(StageLayering.SPRITE_LAYER);
         newClone.updateAllDrawableProperties();

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -67,10 +67,11 @@ class RenderedTarget extends Target {
 
         /**
          * If this target is a named clone, this is its name.
-         * If not, it's just null.
+         * For unnamed clones, this is...
+         * XXX: This is a hack. Find a better way.
          * @type {string}
          */
-        this.cloneName = null;
+        this.cloneName = 'nobody_should_name_their_clones_like_this_anyway';
 
         /**
          * Whether this rendered target represents the Scratch stage.
@@ -184,8 +185,9 @@ class RenderedTarget extends Target {
                 'control_start_as_clone', null, this
             );
             this.runtime.startHats(
-                'control_start_as_named_clone', null, this
-            );
+                'control_start_as_named_clone', {
+                    CLONE_NAME: this.cloneName
+                }, this);
         }
     }
 

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -186,7 +186,7 @@ class RenderedTarget extends Target {
             );
             this.runtime.startHats(
                 'control_start_as_named_clone', {
-                    CLONE_NAME: this.cloneName
+                    CLONE_NAME_OPTION: this.cloneName
                 }, this);
         }
     }

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -186,8 +186,8 @@ class RenderedTarget extends Target {
             // If we're a named clone, start the named clone hats
             if (this.cloneName) {
                 this.runtime.startHats(
-                    'control_start_as_named_clone', {
-                        CLONE_NAME_OPTION: this.cloneName }, this
+                    'control_start_as_named_clone',
+                    {CLONE_NAME_OPTION: this.cloneName}, this
                 );
             }
         }


### PR DESCRIPTION
### Resolves

Closes #34 

### Proposed Changes

Adds execution support for the named clone creation block and named clone hat.

Some important stuff:
* RenderedTargets have a cloneName property, which is null when they are
the original sprint or an anonymous (classical) clone.
* If the cloneName property is not null, startHats for named clones
blocks are called.
* RenderedTarget.makeClone() gained a parameter, namely the cloneName.
It is null if the clone is anonymous, and contains the clone name as a
string if the clone is named. The cloneName property of the
new clone is set according to this parameter.

7c98870 has some details as well.