### PR TITLE
Add dictionary data structure

### DIFF
--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -275,7 +275,7 @@ class Scratch3DataBlocks {
             dict._monitorUpToDate = true;
             // TODO: Make this prettier together with the help of bb-gui
             dict.arrayRepr = Object.keys(dict.value);
-            dict.arrayRepr = dict.arrayRepr.map(key => `${key}:${dict.value[key]}`);
+            dict.arrayRepr = dict.arrayRepr.map(key => `${key}➡${dict.value[key]}`);
             return dict.arrayRepr;
         }
 

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -273,7 +273,6 @@ class Scratch3DataBlocks {
             // If value changed, reset the flag, update the stored array and return a copy to trigger monitor update.
             // Because monitors use Immutable data structures, only new objects trigger updates.
             dict._monitorUpToDate = true;
-            // TODO: Make this prettier together with the help of bb-gui
             dict.arrayRepr = Object.keys(dict.value)
                 .map(key => `${key}➡${dict.value[key]}`);
             return dict.arrayRepr;

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -32,7 +32,9 @@ class Scratch3DataBlocks {
             data_listcontainsitem: this.listContainsItem,
             data_hidelist: this.hideList,
             data_showlist: this.showList,
-            data_dictcontents: this.getDictContents
+            data_dictcontents: this.getDictContents,
+            data_addtodict: this.addToDict,
+            data_itemofdict: this.getItemOfDict
         };
     }
 
@@ -280,6 +282,34 @@ class Scratch3DataBlocks {
             result = `${result}${key}:${dict.value[key]} `;
         }
         return result;
+    }
+
+    addToDict (args, util) {
+        const dict = util.target.lookupOrCreateDict(
+            args.DICT.id, args.DICT.name);
+        if (Object.keys(dict.value).length < Scratch3DataBlocks.DICT_ITEM_LIMIT) {
+            dict.value[args.KEY] = args.ITEM;
+            dict._monitorUpToDate = false;
+        }
+    }
+
+    getItemOfDict (args, util) {
+        const dict = util.target.lookupOrCreateDict(
+            args.DICT.id, args.DICT.name);
+        const item = dict.value[args.KEY];
+        if (!item) {
+            // Match list behaviour by returning empty string for nonexistent item
+            return '';
+        }
+        return item;
+    }
+
+    /**
+     * Maximum number of elements in a dictionary.
+     * @returns {int} the maximum number of elements in a dictionary.
+     */
+    static get DICT_ITEM_LIMIT () {
+        return 200000;
     }
 }
 

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -274,16 +274,14 @@ class Scratch3DataBlocks {
             // Because monitors use Immutable data structures, only new objects trigger updates.
             dict._monitorUpToDate = true;
             // TODO: Make this prettier together with the help of bb-gui
-            dict.arrayRepr = Object.keys(dict.value);
-            dict.arrayRepr = dict.arrayRepr.map(key => `${key}➡${dict.value[key]}`);
+            dict.arrayRepr = Object.keys(dict.value)
+                .map(key => `${key}➡${dict.value[key]}`);
             return dict.arrayRepr;
         }
 
-        let result = '';
-        for (const key in dict.value) {
-            result = `${result}${key}➡${dict.value[key]}\n`;
-        }
-        return result;
+        return Object.keys(dict.value)
+            .map(key => `${key}➡${dict.value[key]}`)
+            .join('\n');
     }
 
     addToDict (args, util) {

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -39,6 +39,7 @@ class Scratch3DataBlocks {
             data_itemofdict: this.getItemOfDict,
             data_lengthofdict: this.lengthOfDict,
             data_dictcontainskey: this.dictContainsKey,
+            data_for_each_key_in_dict: this.forEachKeyInDict,
             data_hidedict: this.hideDict,
             data_showdict: this.showDict
         };
@@ -280,7 +281,7 @@ class Scratch3DataBlocks {
 
         let result = '';
         for (const key in dict.value) {
-            result = `${result}${key}:${dict.value[key]} `;
+            result = `${result}${key}➡${dict.value[key]}\n`;
         }
         return result;
     }
@@ -328,6 +329,23 @@ class Scratch3DataBlocks {
         const dict = util.target.lookupOrCreateDict(
             args.DICT.id, args.DICT.name);
         return args.KEY in dict.value;
+    }
+
+    forEachKeyInDict (args, util) {
+        const variable = util.target.lookupOrCreateVariable(
+            args.VARIABLE.id, args.VARIABLE.name);
+        const entries = args.DICT.split('\n');
+
+        if (typeof util.stackFrame.index === 'undefined') {
+            util.stackFrame.index = 0;
+        }
+
+        if (util.stackFrame.index < entries.length) {
+            const key = entries[util.stackFrame.index].split('➡')[0];
+            variable.value = key;
+            util.stackFrame.index++;
+            util.startBranch(1, true);
+        }
     }
 
     showDict (args) {

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -306,6 +306,7 @@ class Scratch3DataBlocks {
         const dict = util.target.lookupOrCreateDict(
             args.DICT.id, args.DICT.name);
         dict.value = {};
+        dict._monitorUpToDate = false;
     }
 
     getItemOfDict (args, util) {

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -258,25 +258,20 @@ class Scratch3DataBlocks {
         return 200000;
     }
 
-    /*
-     * TODO: In the GUI, dictionary contents does not have a pretty title;
-     * it shows data_dictcontents (the opcode). Fix it.
-     * TODO: Find out how the GUI displays lists the way it does and if possible
-     * make it display the dictionaries in a similar manner.
-     */
     getDictContents (args, util) {
         const dict = util.target.lookupOrCreateDict(
             args.DICT.id, args.DICT.name);
 
-        // TODO: Format the dictionary so that the React monitor displays it in a pretty format.
         if (util.thread.updateMonitor) {
-            // Return original string representation if up-to-date, which doesn't trigger monitor update.
-            if (dict._monitorUpToDate) return dict.stringRepr;
-            // If value changed, reset the flag, update the stored string and return a copy to trigger monitor update.
+            // Return original array representation if up-to-date, which doesn't trigger monitor update.
+            if (dict._monitorUpToDate) return dict.arrayRepr;
+            // If value changed, reset the flag, update the stored array and return a copy to trigger monitor update.
             // Because monitors use Immutable data structures, only new objects trigger updates.
             dict._monitorUpToDate = true;
-            dict.stringRepr = dict.value.toString();
-            return dict.stringRepr;
+            // TODO: Make this prettier together with the help of bb-gui
+            dict.arrayRepr = Object.keys(dict.value);
+            dict.arrayRepr = dict.arrayRepr.map(key => `${key}:${dict.value[key]}`);
+            return dict.arrayRepr;
         }
 
         let result = '';

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -31,7 +31,8 @@ class Scratch3DataBlocks {
             data_lengthoflist: this.lengthOfList,
             data_listcontainsitem: this.listContainsItem,
             data_hidelist: this.hideList,
-            data_showlist: this.showList
+            data_showlist: this.showList,
+            data_dictcontents: this.getDictContents
         };
     }
 
@@ -251,6 +252,34 @@ class Scratch3DataBlocks {
      */
     static get LIST_ITEM_LIMIT () {
         return 200000;
+    }
+
+    /*
+     * TODO: In the GUI, dictionary contents does not have a pretty title;
+     * it shows data_dictcontents (the opcode). Fix it.
+     * TODO: Find out how the GUI displays lists the way it does and if possible
+     * make it display the dictionaries in a similar manner.
+     */
+    getDictContents (args, util) {
+        const dict = util.target.lookupOrCreateDict(
+            args.DICT.id, args.DICT.name);
+
+        // TODO: Format the dictionary so that the React monitor displays it in a pretty format.
+        if (util.thread.updateMonitor) {
+            // Return original string representation if up-to-date, which doesn't trigger monitor update.
+            if (dict._monitorUpToDate) return dict.stringRepr;
+            // If value changed, reset the flag, update the stored string and return a copy to trigger monitor update.
+            // Because monitors use Immutable data structures, only new objects trigger updates.
+            dict._monitorUpToDate = true;
+            dict.stringRepr = dict.value.toString();
+            return dict.stringRepr;
+        }
+
+        let result = '';
+        for (const key in dict.value) {
+            result = `${result}${key}:${dict.value[key]} `;
+        }
+        return result;
     }
 }
 

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -35,6 +35,7 @@ class Scratch3DataBlocks {
             data_dictcontents: this.getDictContents,
             data_addtodict: this.addToDict,
             data_deleteofdict: this.deleteOfDict,
+            data_deleteallofdict: this.deleteAllOfDict,
             data_itemofdict: this.getItemOfDict,
             data_hidedict: this.hideDict,
             data_showdict: this.showDict
@@ -296,6 +297,12 @@ class Scratch3DataBlocks {
             args.DICT.id, args.DICT.name);
         delete dict.value[args.KEY];
         dict._monitorUpToDate = false;
+    }
+
+    deleteAllOfDict (args, util) {
+        const dict = util.target.lookupOrCreateDict(
+            args.DICT.id, args.DICT.name);
+        dict.value = {};
     }
 
     getItemOfDict (args, util) {

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -34,7 +34,9 @@ class Scratch3DataBlocks {
             data_showlist: this.showList,
             data_dictcontents: this.getDictContents,
             data_addtodict: this.addToDict,
-            data_itemofdict: this.getItemOfDict
+            data_itemofdict: this.getItemOfDict,
+            data_hidedict: this.hideDict,
+            data_showdict: this.showDict
         };
     }
 
@@ -302,6 +304,14 @@ class Scratch3DataBlocks {
             return '';
         }
         return item;
+    }
+
+    showDict (args) {
+        this.changeMonitorVisibility(args.DICT.id, true);
+    }
+
+    hideDict (args) {
+        this.changeMonitorVisibility(args.DICT.id, false);
     }
 
     /**

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -34,6 +34,7 @@ class Scratch3DataBlocks {
             data_showlist: this.showList,
             data_dictcontents: this.getDictContents,
             data_addtodict: this.addToDict,
+            data_deleteofdict: this.deleteOfDict,
             data_itemofdict: this.getItemOfDict,
             data_hidedict: this.hideDict,
             data_showdict: this.showDict
@@ -288,6 +289,13 @@ class Scratch3DataBlocks {
             dict.value[args.KEY] = args.ITEM;
             dict._monitorUpToDate = false;
         }
+    }
+
+    deleteOfDict (args, util) {
+        const dict = util.target.lookupOrCreateDict(
+            args.DICT.id, args.DICT.name);
+        delete dict.value[args.KEY];
+        dict._monitorUpToDate = false;
     }
 
     getItemOfDict (args, util) {

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -38,6 +38,7 @@ class Scratch3DataBlocks {
             data_deleteallofdict: this.deleteAllOfDict,
             data_itemofdict: this.getItemOfDict,
             data_lengthofdict: this.lengthOfDict,
+            data_dictcontainskey: this.dictContainsKey,
             data_hidedict: this.hideDict,
             data_showdict: this.showDict
         };
@@ -321,6 +322,12 @@ class Scratch3DataBlocks {
         const dict = util.target.lookupOrCreateDict(
             args.DICT.id, args.DICT.name);
         return Object.keys(dict.value).length;
+    }
+
+    dictContainsKey (args, util) {
+        const dict = util.target.lookupOrCreateDict(
+            args.DICT.id, args.DICT.name);
+        return args.KEY in dict.value;
     }
 
     showDict (args) {

--- a/src/blocks/scratch3_data.js
+++ b/src/blocks/scratch3_data.js
@@ -37,6 +37,7 @@ class Scratch3DataBlocks {
             data_deleteofdict: this.deleteOfDict,
             data_deleteallofdict: this.deleteAllOfDict,
             data_itemofdict: this.getItemOfDict,
+            data_lengthofdict: this.lengthOfDict,
             data_hidedict: this.hideDict,
             data_showdict: this.showDict
         };
@@ -314,6 +315,12 @@ class Scratch3DataBlocks {
             return '';
         }
         return item;
+    }
+
+    lengthOfDict (args, util) {
+        const dict = util.target.lookupOrCreateDict(
+            args.DICT.id, args.DICT.name);
+        return Object.keys(dict.value).length;
     }
 
     showDict (args) {

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -570,7 +570,7 @@ class Blocks {
 
             // Update block value
             if (!block.fields[args.name]) return;
-            if (args.name === 'VARIABLE' || args.name === 'LIST' ||
+            if (args.name === 'VARIABLE' || args.name === 'LIST' || args.name === 'DICT' ||
                 args.name === 'BROADCAST_OPTION' || args.name === 'CLONE_NAME_OPTION') {
                 // Get variable name using the id in args.value.
                 const variable = this.runtime.getEditingTarget().lookupVariableById(args.value);
@@ -611,7 +611,8 @@ class Blocks {
             // block but in the case of monitored reporters that have arguments,
             // map the old id to a new id, creating a new monitor block if necessary
             if (block.fields && Object.keys(block.fields).length > 0 &&
-                block.opcode !== 'data_variable' && block.opcode !== 'data_listcontents') {
+                block.opcode !== 'data_variable' && block.opcode !== 'data_listcontents' &&
+                block.opcode !== 'data_dictcontents') {
 
                 // This block has an argument which needs to get separated out into
                 // multiple monitor blocks with ids based on the selected argument
@@ -639,6 +640,8 @@ class Blocks {
                 isSpriteLocalVariable = !(this.runtime.getTargetForStage().variables[block.fields.VARIABLE.id]);
             } else if (block.opcode === 'data_listcontents') {
                 isSpriteLocalVariable = !(this.runtime.getTargetForStage().variables[block.fields.LIST.id]);
+            } else if (block.opcode === 'data_dictcontents') {
+                isSpriteLocalVariable = !(this.runtime.getTargetForStage().variables[block.fields.DICT.id]);
             }
 
             const isSpriteSpecific = isSpriteLocalVariable ||
@@ -887,6 +890,8 @@ class Blocks {
                 varOrListField = blocks[blockId].fields.VARIABLE;
             } else if (blocks[blockId].fields.LIST) {
                 varOrListField = blocks[blockId].fields.LIST;
+            } else if (blocks[blockId].fields.DICT) {
+                varOrListField = blocks[blockId].fields.DICT;
             }
             if (varOrListField) {
                 const currFieldId = varOrListField.id;

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -658,6 +658,12 @@ class Blocks {
             } else if (!wasMonitored && block.isMonitored) {
                 // Tries to show the monitor for specified block. If it doesn't exist, add the monitor.
                 if (!this.runtime.requestShowMonitor(block.id)) {
+                    let monitorMode = 'default';
+                    if (block.opcode === 'data_listcontents') {
+                        monitorMode = 'list';
+                    } else if (block.opcode === 'data_dictcontents') {
+                        monitorMode = 'dict';
+                    }
                     this.runtime.requestAddMonitor(MonitorRecord({
                         id: block.id,
                         targetId: block.targetId,
@@ -666,7 +672,7 @@ class Blocks {
                         params: this._getBlockParams(block),
                         // @todo(vm#565) for numerical values with decimals, some countries use comma
                         value: '',
-                        mode: block.opcode === 'data_listcontents' ? 'list' : 'default'
+                        mode: monitorMode
                     }));
                 }
             }

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -818,7 +818,7 @@ class Blocks {
     }
 
     /**
-     * Returns a map of all references to variables or lists from blocks
+     * Returns a map of all references to variables, lists and dictionaries from blocks
      * in this block container.
      * @param {Array<object>} optBlocks Optional list of blocks to constrain the search to.
      * This is useful for getting variable/list references for a stack of blocks instead
@@ -840,6 +840,9 @@ class Blocks {
             } else if (blocks[blockId].fields.LIST) {
                 varOrListField = blocks[blockId].fields.LIST;
                 varType = Variable.LIST_TYPE;
+            } else if (blocks[blockId].fields.DICT) {
+                varOrListField = blocks[blockId].fields.DICT;
+                varType = Variable.DICT_TYPE;
             } else if (optIncludeBroadcast && blocks[blockId].fields.BROADCAST_OPTION) {
                 varOrListField = blocks[blockId].fields.BROADCAST_OPTION;
                 varType = Variable.BROADCAST_MESSAGE_TYPE;

--- a/src/engine/execute.js
+++ b/src/engine/execute.js
@@ -295,6 +295,7 @@ class BlockCached {
             if (
                 fieldName === 'VARIABLE' ||
                 fieldName === 'LIST' ||
+                fieldName === 'DICT' ||
                 fieldName === 'BROADCAST_OPTION'
             ) {
                 this._argValues[fieldName] = {

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -423,6 +423,8 @@ class Target extends EventEmitter {
             );
             if (newVariable.type === Variable.LIST_TYPE) {
                 newVariable.value = originalVariable.value.slice(0);
+            } else if (newVariable.type === Variable.DICT_TYPE) {
+                newVariable.value = JSON.parse(JSON.stringify(originalVariable.value));
             } else {
                 newVariable.value = originalVariable.value;
             }

--- a/src/engine/target.js
+++ b/src/engine/target.js
@@ -255,6 +255,26 @@ class Target extends EventEmitter {
     }
 
     /**
+    * Look up a dictionary object for this target, and create it if one doesn't exist.
+    * Search begins for local dictionaries; then look for globals.
+    * @param {!string} id Id of the dictionary.
+    * @param {!string} name Name of the dictionary.
+    * @return {!Varible} Variable object representing the found/created dictionary.
+     */
+    lookupOrCreateDict (id, name) {
+        let dict = this.lookupVariableById(id);
+        if (dict) return dict;
+
+        dict = this.lookupVariableByNameAndType(name, Variable.DICT_TYPE);
+        if (dict) return dict;
+
+        // No variable with this name exists - create it locally.
+        const newDict = new Variable(id, name, Variable.DICT_TYPE, false);
+        this.variables[id] = newDict;
+        return newDict;
+    }
+
+    /**
      * Creates a variable with the given id and name and adds it to the
      * dictionary of variables.
      * @param {string} id Id of variable

--- a/src/engine/variable.js
+++ b/src/engine/variable.js
@@ -27,12 +27,7 @@ class Variable {
             this.value = [];
             break;
         case Variable.DICT_TYPE:
-            /*
-             * TODO: Think about how to implement this. See:
-             * https://stackoverflow.com/questions/7196212/how-to-create-dictionary-and-add-key-value-pairs-dynamically
-             * I'll deal with this later once the general framework is completed.
-             */
-            this.value = [];
+            this.value = {};
             break;
         case Variable.BROADCAST_MESSAGE_TYPE:
         // fall through

--- a/src/engine/variable.js
+++ b/src/engine/variable.js
@@ -26,6 +26,14 @@ class Variable {
         case Variable.LIST_TYPE:
             this.value = [];
             break;
+        case Variable.DICT_TYPE:
+            /*
+             * TODO: Think about how to implement this. See:
+             * https://stackoverflow.com/questions/7196212/how-to-create-dictionary-and-add-key-value-pairs-dynamically
+             * I'll deal with this later once the general framework is completed.
+             */
+            this.value = [];
+            break;
         case Variable.BROADCAST_MESSAGE_TYPE:
         // fall through
         case Variable.CLONE_NAME_TYPE:
@@ -58,6 +66,14 @@ class Variable {
      */
     static get LIST_TYPE () {
         return 'list';
+    }
+
+    /**
+     * Type representation for dict variables.
+     * @const {string}
+     */
+    static get DICT_TYPE () {
+        return 'dict';
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1509,6 +1509,12 @@ class VirtualMachine extends EventEmitter {
             const variable = target.lookupVariableById(variableId);
             if (variable) {
                 variable.value = value;
+                // XXX: Temporary hack
+                // Force a monitor update when a dict is modified from a DictMonitor.
+                // This is not a clean solution.
+                if (variable._monitorUpToDate) {
+                    variable._monitorUpToDate = false;
+                }
 
                 if (variable.isCloud) {
                     this.runtime.ioDevices.cloud.requestUpdateVariable(variable.name, variable.value);


### PR DESCRIPTION
Closes #50.

TODO:
- [x]  Add duplication logic for dictionaries here: https://github.com/FBDY/bb-vm/blob/48f349a89e0961be6977ff1af63fa40c56dfc1cd/src/engine/target.js#L404-L408
For now, they fall to the `else` case which makes a plain assignment. But with a JS object (which is what our dictionary representation is) I guess this will not produce correct behaviour.
- [x] Weird add/get bug -> fixed by b9a82b2
- [x] Show/hide blocks not working -> fixed by b9a82b2
- [x] Add execution support for new blocks as they are added in https://github.com/FBDY/bb-blocks/pull/22
- [x] Design and implement a good representation for the dictionary monitor in GUI https://github.com/FBDY/bb-gui/pull/135
- [x] There are problems with the monitor not updating when the dictionary is cleared by the `delete all of dict` block. However, this will be resolved as a side effect when the monitor work is completed because of reasons that I'm too lazy to explain here. But in any case, don't forget to check if it works when this work is finalized.
- [x] Provide a way to iterate over keys in a dictionary. A `for key in` kind of block?