### PR TITLE
Fix a serialization bug with named clones

### DIFF
--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -408,6 +408,7 @@ const serializeVariables = function (variables) {
         }
         if (v.type === Variable.CLONE_NAME_TYPE) {
             obj.clones[varId] = v.value; // name and value is the same for clone names
+            continue;
         }
 
         // otherwise should be a scalar type


### PR DESCRIPTION
This fixes a bug where a bogus variable is added to the JSON when named
clone blocks are serialized.