### PR TITLE
Migrate remaining variable API functionality to VM

### DIFF
--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1504,7 +1504,9 @@ class VirtualMachine extends EventEmitter {
      * @returns {boolean} whether the target and variable were found and updated.
      */
     setVariableValue (targetId, variableId, value) {
-        const target = this.runtime.getTargetById(targetId);
+        const target = targetId ?
+            this.runtime.getTargetById(targetId) :
+            this.runtime.getTargetForStage();
         if (target) {
             const variable = target.lookupVariableById(variableId);
             if (variable) {
@@ -1527,7 +1529,9 @@ class VirtualMachine extends EventEmitter {
      * @returns {?*} The value of the variable, or null if it could not be looked up.
      */
     getVariableValue (targetId, variableId) {
-        const target = this.runtime.getTargetById(targetId);
+        const target = targetId ?
+            this.runtime.getTargetById(targetId) :
+            this.runtime.getTargetForStage();
         if (target) {
             const variable = target.lookupVariableById(variableId);
             if (variable) {

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1499,6 +1499,7 @@ class VirtualMachine extends EventEmitter {
     /**
      * Set a target's variable's value. Return whether it succeeded.
      * @param {!string} targetId ID of the target which owns the variable.
+     * If null, target is stage.
      * @param {!string} variableId ID of the variable to set.
      * @param {!*} value The new value of that variable.
      * @returns {boolean} whether the target and variable were found and updated.
@@ -1525,6 +1526,7 @@ class VirtualMachine extends EventEmitter {
     /**
      * Get a target's variable's value. Return null if the target or variable does not exist.
      * @param {!string} targetId ID of the target which owns the variable.
+     * If null, target is stage.
      * @param {!string} variableId ID of the variable to set.
      * @returns {?*} The value of the variable, or null if it could not be looked up.
      */

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -1537,7 +1537,8 @@ class VirtualMachine extends EventEmitter {
         if (target) {
             const variable = target.lookupVariableById(variableId);
             if (variable) {
-                return variable.value;
+                // Return a new copy for mutating, ensuring that updates stay immutable.
+                return JSON.parse(JSON.stringify(variable.value));
             }
         }
         return null;


### PR DESCRIPTION
### Proposed Changes

Move the "look at sprite or the stage" logic when looking up variables (which was the behavior of GUI's variable util) into the VM API.

This is (I think) in accordance with the comments here: https://github.com/FBDY/bb-gui/blob/72042e545f7b745278724833492efba0deccc7e4/src/lib/variable-utils.js#L1-L2

Once this is merged, I can refactor the monitor codes to use the VM API and remove the variable util from the GUI altogether.

This is also required for dict value updates in https://github.com/FBDY/bb-gui/pull/135 to work properly.